### PR TITLE
Same versions are marked as NonMatchingUpdate

### DIFF
--- a/main.go
+++ b/main.go
@@ -208,7 +208,7 @@ func updates(r *moduleReference, out chan outputUpdates) error {
 	case r.Version == nil && currentVersion == nil:
 		versionConstraintString = "*"
 	case r.Version == nil && currentVersion != nil:
-		versionConstraintString = fmt.Sprintf(">%s", currentVersion.String())
+		versionConstraintString = fmt.Sprintf(">=%s", currentVersion.String())
 	case r.Version != nil && currentVersion == nil:
 		versionConstraintString = *r.Version
 	case r.Version != nil && currentVersion != nil:


### PR DESCRIPTION
Before change:
```
| UPDATE? |      NAME      | CONSTRAINT | VERSION | LATEST MATCHING | LATEST |
|---------|----------------|------------|---------|-----------------|--------|
| (Y)     | keygen         |            | 1.1.1   |                 | 1.1.1  |
| (Y)     | bootstrap_2019 |            | 1.1.1   |                 | 1.1.1  |
| (Y)     | bootstrap_2016 |            | 1.1.1   |                 | 1.1.1  |
```

After change:
```
| UPDATE? |      NAME      | CONSTRAINT | VERSION | LATEST MATCHING | LATEST |
|---------|----------------|------------|---------|-----------------|--------|
|         | keygen         |            | 1.1.1   |                 | 1.1.1  |
|         | bootstrap_2019 |            | 1.1.1   |                 | 1.1.1  |
|         | bootstrap_2016 |            | 1.1.1   |                 | 1.1.1  |
```