### PR TITLE
Module version shall not be required

### DIFF
--- a/main.go
+++ b/main.go
@@ -205,13 +205,13 @@ func updates(r *moduleReference, out chan outputUpdates) error {
 		}
 	}
 	switch {
-	case r.Version == nil && currentVersion == nil:
+	case *r.Version == "" && currentVersion == nil:
 		versionConstraintString = "*"
-	case r.Version == nil && currentVersion != nil:
+	case *r.Version == "" && currentVersion != nil:
 		versionConstraintString = fmt.Sprintf(">=%s", currentVersion.String())
-	case r.Version != nil && currentVersion == nil:
+	case *r.Version != "" && currentVersion == nil:
 		versionConstraintString = *r.Version
-	case r.Version != nil && currentVersion != nil:
+	case *r.Version != "" && currentVersion != nil:
 		versionConstraintString = fmt.Sprintf("%s,>%s", *r.Version, currentVersion.String())
 	}
 	versionConstraint, err := semver.ParseConstraint(versionConstraintString)


### PR DESCRIPTION
Module version shall not be required for git registry.

```
[terrafile-module-versions] "git::ssh://git@priv.domain/modules/terraform-common-module.git//bootstrap?ref=v1.1.1" ("bootstrap_2016" in main.tf): parse version constraint ",>1.1.1": improper constraint
```