### PR TITLE
Add support for "scp-like" address syntax

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -17,3 +17,8 @@ module "example_git_ssh" {
   source = "git::ssh://git@github.com/keilerkonzept/terraform-module-versions?ref=0.10.0"
   version = "~> 0.10"
 }
+
+module "example_git_scp" {
+  source = "git::git@github.com:keilerkonzept/terraform-module-versions?ref=0.12.0"
+  version = "~> 0.12"
+}

--- a/reference.go
+++ b/reference.go
@@ -9,6 +9,7 @@ import (
 
 // Module source prefixes
 const (
+	ModuleSourceGitSSHPrefix        = "git::ssh://"
 	ModuleSourceGitPrefix           = "git::"
 	ModuleSourceGithubHTTPSPrefix   = "github.com/"
 	ModuleSourceGithubSSHPrefix     = "git@github.com:"
@@ -98,8 +99,12 @@ func (r *moduleReference) ParseSource() error {
 		strings.HasPrefix(r.Source, ModuleSourceLocalPathPrefix2):
 		r.parseLocalPath(r.Source)
 		return nil
-	case strings.HasPrefix(r.Source, ModuleSourceGitPrefix):
+	case strings.HasPrefix(r.Source, ModuleSourceGitSSHPrefix):
 		return r.parseGit(r.Source)
+	case strings.HasPrefix(r.Source, ModuleSourceGitPrefix):
+	    source := strings.TrimPrefix(r.Source, ModuleSourceGitPrefix)
+	    source = strings.Replace(source, ":", "/", 1)
+	    return r.parseGit("ssh://" + source)
 	case strings.HasPrefix(r.Source, ModuleSourceGithubHTTPSPrefix):
 		return r.parseGit("https://" + r.Source)
 	case strings.HasPrefix(r.Source, ModuleSourceGithubSSHPrefix):


### PR DESCRIPTION
Module git address can be also "scp-like":
```
module "storage" {
  source = "git::username@example.com:storage.git"
}
```