### PR TITLE
feat: Add optional sed statements generation

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ var (
 		MatchingUpdatesFoundNonzeroExit bool
 		AnyUpdatesFoundNonzeroExit      bool
 		All                             bool
+		GenerateSed                     bool
 	}
 )
 
@@ -77,6 +78,7 @@ func main() {
 	checkFlagSet.Var(&config.ModuleNames, "module", "include this module (may be specified repeatedly. by default, all modules are included)")
 	checkFlagSet.Var(&config.RegistryHeaders, "H", "(alias for -registry-header)")
 	checkFlagSet.Var(&config.RegistryHeaders, "registry-header", fmt.Sprintf("extra HTTP headers for requests to Terraform module registries (%s, may be specified repeatedly)", config.RegistryHeaders.Help()))
+	checkFlagSet.BoolVar(&config.GenerateSed, "sed", config.GenerateSed, "generate sed statements for upgrade")
 
 	cmdList := &ffcli.Command{
 		Name:       "list",
@@ -243,6 +245,11 @@ func updates(scanResults []scan.Result) {
 	if err := out.Format(os.Stdout, config.OutputFormat); err != nil {
 		log.Fatal(err)
 	}
+
+	if config.GenerateSed {
+		out.GenerateSed()
+	}
+
 	if config.MatchingUpdatesFoundNonzeroExit {
 		if foundMatchingUpdates {
 			os.Exit(1)

--- a/pkg/output/updates.go
+++ b/pkg/output/updates.go
@@ -5,6 +5,9 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"os"
+	"runtime"
+	"strings"
 
 	junit "github.com/jstemmer/go-junit-report/formatter"
 	"github.com/olekukonko/tablewriter"
@@ -63,6 +66,18 @@ func (u Updates) WriteJSON(w io.Writer) error {
 	enc := json.NewEncoder(w)
 	enc.SetEscapeHTML(false)
 	return enc.Encode(u)
+}
+
+func (u Updates) GenerateSed() {
+	io.WriteString(os.Stdout, "\nTo upgrade modules to the latest version, run the following commands:\n\n")
+	for _, item := range u {
+		sed := "sed"
+		if runtime.GOOS == "darwin" {
+			sed = "gsed"
+		}
+		newversion := strings.Replace(item.Source, item.Version, item.LatestOverall, -1)
+		io.WriteString(os.Stdout, fmt.Sprintf("%s -i 's#%s#%s#g' %s\n", sed, item.Source, newversion, item.Path))
+	}
 }
 
 func (u Updates) WriteMarkdownWide(w io.Writer) error {


### PR DESCRIPTION
Added a `-sed` option to `check` to generate sed statements to upgrade to the latest version.

Example output:
```
emporio-terraform/nonprod git:(vlazarenko/module_updates) $ terraform-module-versions check -sed .
| UPDATE? |          NAME           | CONSTRAINT | VERSION | LATEST MATCHING | LATEST |
|---------|-------------------------|------------|---------|-----------------|--------|
| (Y)     | emporio_apis            |            | v1.2.0  |                 | v2.0.0 |
| (Y)     | emporio_external        |            | v1.2.0  |                 | v2.0.0 |
| (Y)     | emporio_customer_ad_app |            | v1.2.0  |                 | v2.0.0 |

To upgrade modules to the latest version, run the following commands:

gsed -i 's#git::git@ssh.dev.azure.com:v3/xxx/azure/terraform-azuread-sp?ref=v1.2.0#git::git@ssh.dev.azure.com:v3/xxx/azure/terraform-azuread-sp?ref=v2.0.0#g' aad_apps.tf
gsed -i 's#git::git@ssh.dev.azure.com:v3/xxx/azure/terraform-azuread-sp?ref=v1.2.0#git::git@ssh.dev.azure.com:v3/xxx/azure/terraform-azuread-sp?ref=v2.0.0#g' aad_apps.tf
gsed -i 's#git::git@ssh.dev.azure.com:v3/xxx/azure/terraform-azuread-sp?ref=v1.2.0#git::git@ssh.dev.azure.com:v3/xxx/azure/terraform-azuread-sp?ref=v2.0.0#g' emporio-b2c-ad-apps.tf
```