### PR TITLE
Add module name to the output

### DIFF
--- a/main.go
+++ b/main.go
@@ -224,6 +224,7 @@ func updates(scanResults []scan.Result) {
 		updateOutput := output.Update{
 			Path:              m.Path,
 			Name:              m.ModuleCall.Name,
+			ModuleName:        parsed.ModuleName,
 			Source:            m.ModuleCall.Source,
 			VersionConstraint: parsed.ConstraintsString,
 			Version:           parsed.VersionString,

--- a/pkg/modulecall/parse.go
+++ b/pkg/modulecall/parse.go
@@ -2,6 +2,7 @@ package modulecall
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"
@@ -10,6 +11,7 @@ import (
 
 type Parsed struct {
 	Source            *source.Source
+	ModuleName        string
 	Version           *semver.Version
 	VersionString     string
 	Constraints       *semver.Constraints
@@ -22,7 +24,8 @@ func Parse(raw tfconfig.ModuleCall) (*Parsed, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse module call source: %w", err)
 	}
-	out := Parsed{Source: src, Raw: raw}
+	name := src.Git.Remote[strings.LastIndex(src.Git.Remote, "/")+1:]
+	out := Parsed{Source: src, Raw: raw, ModuleName: name}
 	switch {
 	case src.Git != nil:
 		if ref := src.Git.RefValue; ref != nil {

--- a/pkg/output/updates.go
+++ b/pkg/output/updates.go
@@ -22,6 +22,7 @@ func (u Updates) Swap(i, j int)      { u[i], u[j] = u[j], u[i] }
 type Update struct {
 	Path              string `json:"path,omitempty"`
 	Name              string `json:"name,omitempty"`
+	ModuleName        string `json:"modulename,omitempty"`
 	Source            string `json:"source,omitempty"`
 	VersionConstraint string `json:"constraint,omitempty"`
 	Version           string `json:"version,omitempty"`
@@ -82,7 +83,7 @@ func (u Updates) GenerateSed() {
 
 func (u Updates) WriteMarkdownWide(w io.Writer) error {
 	table := tablewriter.NewWriter(w)
-	table.SetHeader([]string{"Update?", "Name", "Path", "Source", "Constraint", "Version", "Latest matching", "Latest"})
+	table.SetHeader([]string{"Update?", "Name", "Module Name", "Path", "Source", "Constraint", "Version", "Latest matching", "Latest"})
 	table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
 	table.SetCenterSeparator("|")
 	rows := make([][]string, 0, len(u))
@@ -96,7 +97,7 @@ func (u Updates) WriteMarkdownWide(w io.Writer) error {
 		case item.Version == "":
 			update = "?"
 		}
-		row := []string{update, item.Name, item.Path, item.Source, item.VersionConstraint, item.Version, item.LatestMatching, item.LatestOverall}
+		row := []string{update, item.Name, item.ModuleName, item.Path, item.Source, item.VersionConstraint, item.Version, item.LatestMatching, item.LatestOverall}
 		rows = append(rows, row)
 	}
 	table.AppendBulk(rows)
@@ -106,7 +107,7 @@ func (u Updates) WriteMarkdownWide(w io.Writer) error {
 
 func (u Updates) WriteMarkdown(w io.Writer) error {
 	table := tablewriter.NewWriter(w)
-	table.SetHeader([]string{"Update?", "Name", "Constraint", "Version", "Latest matching", "Latest"})
+	table.SetHeader([]string{"Update?", "Name", "Module Name", "Constraint", "Version", "Latest matching", "Latest"})
 	table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
 	table.SetCenterSeparator("|")
 	rows := make([][]string, 0, len(u))
@@ -120,7 +121,7 @@ func (u Updates) WriteMarkdown(w io.Writer) error {
 		case item.Version == "":
 			update = "?"
 		}
-		row := []string{update, item.Name, item.VersionConstraint, item.Version, item.LatestMatching, item.LatestOverall}
+		row := []string{update, item.Name, item.ModuleName, item.VersionConstraint, item.Version, item.LatestMatching, item.LatestOverall}
 		rows = append(rows, row)
 	}
 	table.AppendBulk(rows)


### PR DESCRIPTION
Added the name of the module to the tabled output.
Example output:

```
| UPDATE? |             NAME              |             MODULE NAME              | CONSTRAINT |      VERSION      | LATEST MATCHING | LATEST |
|---------|-------------------------------|--------------------------------------|------------|-------------------|-----------------|--------|
| (Y)     | adf                           | terraform-azurerm-datafactory        |            | v1.5.0            |                 | v2.0.2 |
| (Y)     | databricks_atlas_data_request | terraform-azurerm-atlas-data-request |            | v0.0.1            |                 | v0.0.3 |
```