### PR TITLE
feat: search local modules for nested modules

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ var (
 		All                             bool
 		GenerateSed                     bool
 		IncludePrereleaseVersions       bool
+		SearchLocalModules              bool
 	}
 )
 
@@ -75,6 +76,8 @@ func main() {
 	checkFlagSet.BoolVar(&config.AnyUpdatesFoundNonzeroExit, "n", config.AnyUpdatesFoundNonzeroExit, "(alias for -any-updates-found-nonzero-exit)")
 	checkFlagSet.BoolVar(&config.AnyUpdatesFoundNonzeroExit, "any-updates-found-nonzero-exit", config.AnyUpdatesFoundNonzeroExit, "exit with a nonzero code when modules with updates are found (ignoring version constraints)")
 	checkFlagSet.BoolVar(&config.IncludePrereleaseVersions, "pre-release", config.IncludePrereleaseVersions, "include pre-release versions")
+	checkFlagSet.BoolVar(&config.SearchLocalModules, "s", config.SearchLocalModules, "(alias for -search-local-modules)")
+	checkFlagSet.BoolVar(&config.SearchLocalModules, "search-local-modules", config.SearchLocalModules, "search for all modules in local modules")
 	checkFlagSet.BoolVar(&config.All, "a", config.All, "(alias for -all)")
 	checkFlagSet.BoolVar(&config.All, "all", config.All, "include modules without updates")
 	listFlagSet.Var(&config.ModuleNames, "module", "include this module (may be specified repeatedly. by default, all modules are included)")
@@ -160,7 +163,7 @@ func main() {
 }
 
 func scanForModuleCalls() []scan.Result {
-	scanResults, err := scan.Scan(config.Paths)
+	scanResults, err := scan.Scan(config.Paths, config.SearchLocalModules)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/scan/scanner.go
+++ b/pkg/scan/scanner.go
@@ -2,17 +2,23 @@ package scan
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"
+	"github.com/keilerkonzept/terraform-module-versions/pkg/modulecall"
 )
+
+// if the local module search goes more than this number, it will stop searching.
+const MaxRecursionDepth int = 10
 
 type Result struct {
 	ModuleCall tfconfig.ModuleCall
 	Path       string
 }
 
-func Scan(paths []string) ([]Result, error) {
+func Scan(paths []string, searchLocalModules bool) ([]Result, error) {
 	var out []Result
+
 	for _, path := range paths {
 		module, err := tfconfig.LoadModule(path)
 		if err != nil {
@@ -28,5 +34,65 @@ func Scan(paths []string) ([]Result, error) {
 			})
 		}
 	}
+
+	if searchLocalModules {
+		var err error
+
+		out, err = scanLocalModules(out, MaxRecursionDepth)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return out, nil
+}
+
+//	This function scans for nested terraform modules by parsing local modules recursively.
+func scanLocalModules(modules []Result, depth int) ([]Result, error) {
+	var out []Result
+
+	if depth < 0 {
+		fmt.Printf("[WARN] Max depth of %d was reached. Module dependencies may have a loop that causes infinite recursion.\n", MaxRecursionDepth)
+		return out, nil
+	}
+
+	for _, m := range modules {
+		dirPath := filepath.Dir(m.Path)
+		parsed, err := modulecall.Parse(m.ModuleCall)
+		if err != nil {
+			return nil, err
+		}
+
+		// if the module source is local, load the nested module and scan for more local modules
+		if parsed.Source.Local != nil {
+			module, err := tfconfig.LoadModule(dirPath + "/" + m.ModuleCall.Source)
+			if err != nil {
+				return nil, fmt.Errorf("read terraform module %q: %w", m.ModuleCall.Source, err)
+			}
+
+			for _, call := range module.ModuleCalls {
+				if call == nil {
+					continue
+				}
+				mod := Result{
+					Path:       call.Pos.Filename,
+					ModuleCall: *call,
+				}
+
+				singleModule := make([]Result, 0)
+				singleModule = append(singleModule, mod)
+
+				nestedModules, err := scanLocalModules(singleModule, depth-1)
+				if err != nil {
+					return nil, err
+				}
+
+				out = append(out, nestedModules...)
+			}
+		}
+	}
+
+	result := append(modules, out...)
+
+	return result, nil
 }


### PR DESCRIPTION
Currently, if a local module uses another module that is sourced from Github or the Registry, it is not shown in the list of outdated modules.

This PR adds another option on the CLI to optionally search local modules for nested modules.
