### PR TITLE
fix(versioning): fix go module version to match current major version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/keilerkonzept/terraform-module-versions
+module github.com/keilerkonzept/terraform-module-versions/v3
 
 go 1.23.3
 

--- a/main.go
+++ b/main.go
@@ -13,12 +13,12 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/keilerkonzept/terraform-module-versions/pkg/httputil"
-	"github.com/keilerkonzept/terraform-module-versions/pkg/modulecall"
-	"github.com/keilerkonzept/terraform-module-versions/pkg/output"
-	"github.com/keilerkonzept/terraform-module-versions/pkg/registry"
-	"github.com/keilerkonzept/terraform-module-versions/pkg/scan"
-	"github.com/keilerkonzept/terraform-module-versions/pkg/update"
+	"github.com/keilerkonzept/terraform-module-versions/v3/pkg/httputil"
+	"github.com/keilerkonzept/terraform-module-versions/v3/pkg/modulecall"
+	"github.com/keilerkonzept/terraform-module-versions/v3/pkg/output"
+	"github.com/keilerkonzept/terraform-module-versions/v3/pkg/registry"
+	"github.com/keilerkonzept/terraform-module-versions/v3/pkg/scan"
+	"github.com/keilerkonzept/terraform-module-versions/v3/pkg/update"
 
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/peterbourgon/ff/v3/ffcli"

--- a/pkg/modulecall/parse.go
+++ b/pkg/modulecall/parse.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"
-	"github.com/keilerkonzept/terraform-module-versions/pkg/source"
+	"github.com/keilerkonzept/terraform-module-versions/v3/pkg/source"
 )
 
 type Parsed struct {

--- a/pkg/update/updates.go
+++ b/pkg/update/updates.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/go-git/go-git/v5/plumbing/transport"
-	"github.com/keilerkonzept/terraform-module-versions/pkg/registry"
-	"github.com/keilerkonzept/terraform-module-versions/pkg/source"
-	"github.com/keilerkonzept/terraform-module-versions/pkg/versions"
+	"github.com/keilerkonzept/terraform-module-versions/v3/pkg/registry"
+	"github.com/keilerkonzept/terraform-module-versions/v3/pkg/source"
+	"github.com/keilerkonzept/terraform-module-versions/v3/pkg/versions"
 )
 
 type Client struct {

--- a/pkg/versions/registry.go
+++ b/pkg/versions/registry.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/keilerkonzept/terraform-module-versions/pkg/registry"
+	"github.com/keilerkonzept/terraform-module-versions/v3/pkg/registry"
 )
 
 func Registry(client registry.Client, hostname, namespace, name, system string) ([]*semver.Version, error) {


### PR DESCRIPTION
This should also let us `go install github.com/keilerkonzept/terraform-module-versions@latest` properly again